### PR TITLE
Fix opcache patch for PHP 8.3.11+ and 8.2.23+

### DIFF
--- a/patches/static_opcache_82.patch
+++ b/patches/static_opcache_82.patch
@@ -1,0 +1,129 @@
+diff --git a/build/order_by_dep.awk b/build/order_by_dep.awk
+index 1e71ea20..77895167 100644
+--- a/build/order_by_dep.awk
++++ b/build/order_by_dep.awk
+@@ -37,6 +37,11 @@ function get_module_index(name,  i)
+ function do_deps(mod_idx,        module_name, mod_name_len, dep, ext, val, depidx)
+ {
+ 	module_name = mods[mod_idx];
++	# TODO: real skip zend extension
++    if (module_name == "opcache") {
++    	delete mods[mod_idx];
++    	return;
++    }
+ 	mod_name_len = length(module_name);
+ 
+ 	for (ext in mod_deps) {
+diff --git a/ext/opcache/ZendAccelerator.c b/ext/opcache/ZendAccelerator.c
+index 9bcd035c..7bc01614 100644
+--- a/ext/opcache/ZendAccelerator.c
++++ b/ext/opcache/ZendAccelerator.c
+@@ -93,7 +93,10 @@ typedef int gid_t;
+ #include <immintrin.h>
+ #endif
+ 
++#ifdef COMPILE_DL_OPCACHE
++// avoid symbol conflict
+ ZEND_EXTENSION();
++#endif
+ 
+ #ifndef ZTS
+ zend_accel_globals accel_globals;
+@@ -4792,7 +4795,11 @@ static int accel_finish_startup(void)
+ 	return SUCCESS;
+ }
+ 
++#ifdef COMPILE_DL_OPCACHE
+ ZEND_EXT_API zend_extension zend_extension_entry = {
++#else
++zend_extension opcache_zend_extension_entry = {
++#endif
+ 	ACCELERATOR_PRODUCT_NAME,               /* name */
+ 	PHP_VERSION,							/* version */
+ 	"Zend Technologies",					/* author */
+diff --git a/ext/opcache/config.m4 b/ext/opcache/config.m4
+index b3929382..8607ff25 100644
+--- a/ext/opcache/config.m4
++++ b/ext/opcache/config.m4
+@@ -21,7 +21,8 @@ PHP_ARG_ENABLE([opcache-jit],
+ if test "$PHP_OPCACHE" != "no"; then
+ 
+   dnl Always build as shared extension
+-  ext_shared=yes
++  dnl why?
++  dnl ext_shared=yes
+ 
+   if test "$PHP_HUGE_CODE_PAGES" = "yes"; then
+     AC_DEFINE(HAVE_HUGE_CODE_PAGES, 1, [Define to enable copying PHP CODE pages into HUGE PAGES (experimental)])
+@@ -336,7 +337,9 @@ int main(void) {
+ 	shared_alloc_mmap.c \
+ 	shared_alloc_posix.c \
+ 	$ZEND_JIT_SRC,
+-	shared,,"$PHP_OPCACHE_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
++	$ext_shared,,"$PHP_OPCACHE_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
++
++	AC_DEFINE(HAVE_OPCACHE, 1, [opcache enabled])
+ 
+   PHP_ADD_EXTENSION_DEP(opcache, pcre)
+ 
+diff --git a/ext/opcache/config.w32 b/ext/opcache/config.w32
+index 764a2eda..95427090 100644
+--- a/ext/opcache/config.w32
++++ b/ext/opcache/config.w32
+@@ -16,7 +16,9 @@ if (PHP_OPCACHE != "no") {
+ 		zend_persist_calc.c \
+ 		zend_file_cache.c \
+ 		zend_shared_alloc.c \
+-		shared_alloc_win32.c", true, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
++		shared_alloc_win32.c", PHP_OPCACHE_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
++
++	AC_DEFINE('HAVE_OPCACHE', 1, 'opcache enabled');
+ 
+ 	if (PHP_OPCACHE_JIT == "yes") {
+ 		if (CHECK_HEADER_ADD_INCLUDE("dynasm/dasm_x86.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
+diff --git a/main/main.c b/main/main.c
+index 0adecd10..ee89ebfb 100644
+--- a/main/main.c
++++ b/main/main.c
+@@ -2048,6 +2048,18 @@ void dummy_invalid_parameter_handler(
+ }
+ #endif
+ 
++// this can be moved to other place
++#if defined(HAVE_OPCACHE) && !defined(COMPILE_DL_OPCACHE)
++extern zend_extension opcache_zend_extension_entry;
++extern void zend_register_extension(zend_extension *new_extension, void *handle);
++
++int zend_load_static_extensions(void)
++{
++	zend_register_extension(&opcache_zend_extension_entry, NULL /*opcache cannot be unloaded*/);
++	return 0;
++}
++#endif
++
+ /* {{{ php_module_startup */
+ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_module)
+ {
+@@ -2293,6 +2305,9 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
+ 	   ahead of all other internals
+ 	 */
+ 	php_ini_register_extensions();
++#if defined(HAVE_OPCACHE) && !defined(COMPILE_DL_OPCACHE)
++	zend_load_static_extensions();
++#endif
+ 	zend_startup_modules();
+ 
+ 	/* start Zend extensions */
+diff --git a/win32/build/confutils.js b/win32/build/confutils.js
+index 4eece379..59b7bd5c 100644
+--- a/win32/build/confutils.js
++++ b/win32/build/confutils.js
+@@ -1534,6 +1534,8 @@ function EXTENSION(extname, file_list, shared, cflags, dllname, obj_dir)
+ 			}
+ 		}
+ 
++        // TODO: real skip zend extensions
++        if (extname != 'opcache')
+ 		extension_module_ptrs += '\tphpext_' + extname + '_ptr,\r\n';
+ 
+ 		DEFINE('CFLAGS_' + EXT + '_OBJ', '$(CFLAGS_PHP) $(CFLAGS_' + EXT + ')');

--- a/patches/static_opcache_83.patch
+++ b/patches/static_opcache_83.patch
@@ -45,27 +45,28 @@ diff --git a/ext/opcache/config.m4 b/ext/opcache/config.m4
 index 2a83fa2455..7b3b37182e 100644
 --- a/ext/opcache/config.m4
 +++ b/ext/opcache/config.m4
-@@ -21,7 +21,8 @@ PHP_ARG_ENABLE([opcache-jit],
+@@ -27,7 +27,8 @@
  if test "$PHP_OPCACHE" != "no"; then
- 
+
    dnl Always build as shared extension
 -  ext_shared=yes
 +  dnl why?
 +  dnl ext_shared=yes
- 
+
    if test "$PHP_HUGE_CODE_PAGES" = "yes"; then
      AC_DEFINE(HAVE_HUGE_CODE_PAGES, 1, [Define to enable copying PHP CODE pages into HUGE PAGES (experimental)])
-@@ -327,7 +328,9 @@ int main() {
- 	shared_alloc_mmap.c \
- 	shared_alloc_posix.c \
- 	$ZEND_JIT_SRC,
--	shared,,"-Wno-implicit-fallthrough -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
-+	$ext_shared,,"-Wno-implicit-fallthrough -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
+@@ -319,8 +320,10 @@
+	shared_alloc_mmap.c \
+	shared_alloc_posix.c \
+	$ZEND_JIT_SRC,
+-	shared,,"$PHP_OPCACHE_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
++	$ext_shared,,"$PHP_OPCACHE_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
+
++  AC_DEFINE(HAVE_OPCACHE, 1, [opcache enabled])
 +
-+	AC_DEFINE(HAVE_OPCACHE, 1, [opcache enabled])
- 
    PHP_ADD_EXTENSION_DEP(opcache, pcre)
- 
+
+   if test "$have_shm_ipc" != "yes" && test "$have_shm_mmap_posix" != "yes" && test "$have_shm_mmap_anon" != "yes"; then
 diff --git a/ext/opcache/config.w32 b/ext/opcache/config.w32
 index 764a2edaab..95427090ce 100644
 --- a/ext/opcache/config.w32


### PR DESCRIPTION
PHP 8.3.11 (and 8.2.23) changed these lines in their `ext/opcache/config.m4` which leads to issues that the patch file can not be applied.

https://github.com/php/php-src/compare/php-8.3.10...php-8.3.11#diff-fba8aed1e512099e6635bd4d9ffd939e0489105bc6b2c68d0bfe1abb0ee1007cR322

This PR fixes the patch file for PHP 8.3 - but there are some things missing where I could use your help:

Please note that I'm not using phpmicro directly, but via static-php-cli. 
Also see this issue https://github.com/crazywhalecc/static-php-cli/issues/527

- [x] This patch will not work with PHP versions < 8.3.11 and 8.2.23 so I guess there needs to be some logic for this. Not sure if this needs to be applied in micro's codebase or in static-php's codebase (or both)
- [x] There's currently no PHP 8.2 patch for opcache as it seems to use the one for PHP 8.1, so this needs to be updated accordingly
- [X] ~When building PHP using `static-php-cli` with this patch applied, the opcache extension is missing. Not sure if this is an issue in phpmicro or in static-php-cli~