### PR TITLE
Add stable PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,8 @@ jobs:
             <(curl -sfSL 'https://www.php.net/releases/?json&max=1&version=8.0') \
             <(curl -sfSL 'https://www.php.net/releases/?json&max=1&version=8.1') \
             <(curl -sfSL 'https://www.php.net/releases/?json&max=1&version=8.2') \
-            <(curl -sfSL 'https://www.php.net/releases/?json&max=1&version=8.3') >> $GITHUB_OUTPUT
+            <(curl -sfSL 'https://www.php.net/releases/?json&max=1&version=8.3') \
+            <(curl -sfSL 'https://www.php.net/releases/?json&max=1&version=8.4') >> $GITHUB_OUTPUT
   wintests:
     name: Windows tests for PHP ${{ matrix.name }}
     runs-on: "windows-latest"


### PR DESCRIPTION
Hi!

The PHP master branch breaks every now and then. This patch adds the latest 8.4 branch in the build matrix, ensuring a more reliable run for this version.

This is value of the version array after the patch:

```json
[
  {
    "name": "master",
    "rev": "master",
    "patch": "84"
  },
  {
    "name": "8.0.30",
    "rev": "php-8.0.30",
    "patch": "80"
  },
  {
    "name": "8.1.32",
    "rev": "php-8.1.32",
    "patch": "81"
  },
  {
    "name": "8.2.28",
    "rev": "php-8.2.28",
    "patch": "82"
  },
  {
    "name": "8.3.19",
    "rev": "php-8.3.19",
    "patch": "83"
  },
  {
    "name": "8.4.5",
    "rev": "php-8.4.5",
    "patch": "84"
  }
]
```

Let me know if there is something else I should change.